### PR TITLE
update write and touch methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.5.0] - 2018-05-01
+### Changed
+- bring back :perm as option to set the permissions in SugarUtils::File.write and SugarUtils::File.touch methods
+- :mode option in SugarUtils::File.write is now to be used for setting the file mode (e.g. read/write, append, etc). It can still be used for setting the permissions if it is an integer value for backwards compatibility purposes, but this usage has been deprecated.
+
 ## [0.4.4] - 2018-01-31
 ### Changed
 - fixed a bug in SugarUtils::File.read_json which it would raise an exception

--- a/lib/sugar_utils/version.rb
+++ b/lib/sugar_utils/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module SugarUtils
-  VERSION = '0.4.4'
+  VERSION = '0.5.0'
 end

--- a/spec/sugar_utils/file_spec.rb
+++ b/spec/sugar_utils/file_spec.rb
@@ -171,7 +171,7 @@ describe SugarUtils::File do
         end
 
         context 'with deprecated options' do
-          let(:options) { { perm: 0o600 } }
+          let(:options) { { mode: 0o600 } }
           before { subject }
           specify { expect(filename).to have_content(data) }
           specify { expect(filename).to have_file_permission(0o100600) }
@@ -179,7 +179,7 @@ describe SugarUtils::File do
 
         context 'without deprecated options' do
           let(:options) do
-            { flush: true, owner: 'nobody', group: 'nogroup', mode: 0o600 }
+            { flush: true, owner: 'nobody', group: 'nogroup', mode: 'w', perm: 0o600 }
           end
           before do
             expect_any_instance_of(File).to receive(:flush)
@@ -201,6 +201,16 @@ describe SugarUtils::File do
         before { write(filename, 'foobar', 0o777) }
         context 'not locked' do
           it_behaves_like 'file is written'
+
+          context 'with append mode' do
+            let(:options) { { mode: 'a+' } }
+            before do
+              expect(described_class).to receive(:flock_exclusive)
+                .with(kind_of(File), options)
+              subject
+            end
+            specify { expect(filename).to have_content("foobar#{data}") }
+          end
         end
       end
     end


### PR DESCRIPTION
* allow setting the file open mode.
* Revert previous change to rename perm option mode. This is due to the
naming of the Ruby’s File::open method arguments