### PR TITLE
Seperate append and overwrite functionality

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,18 +4,24 @@ rvm:
   - 2.3
   - 2.4
   - 2.5
+  - 2.6
   - ruby-head
   - jruby
 matrix:
+  exclude:
+    - rvm: jruby
+      os: osx
+    - rvm: ruby-head
+      os: osx
   allow_failures:
     - rvm: ruby-head
-    - rvm: 2.4
-      os: osx
     - rvm: jruby
 os:
   - linux
   - osx
 sudo: false
+cache:
+  bundler: true
 before_script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-darwin-amd64 > ./cc-test-reporter ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter ; fi
@@ -23,3 +29,11 @@ before_script:
   - ./cc-test-reporter before-build
 after_script:
   - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
+
+# HACK: Continue to use bundler <2 because of Ruby v2.2 support. Once the
+# lowest dependency is Ruby v2.3 we can consider upgrading to Bundler 2.x.
+# @see https://docs.travis-ci.com/user/languages/ruby/#bundler-20
+before_install:
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem install bundler -v '< 2'
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- SugarUtils::File.append, which is explicitly for appending to a file. It will
+  also create a new file if it does not yet exist
 
 ## [0.5.0] - 2018-05-01
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - SugarUtils::File.append, which is explicitly for appending to a file. It will
   also create a new file if it does not yet exist
+### Removed
+- append support in SugarUtils::File.write (could have been specified by { mode: 'a })
+### Changed
+- :mode and :perm are now aliases for setting permissions on files in all the
+  related methods (i.e., .write, .write_json, .touch, .append)
 
 ## [0.5.0] - 2018-05-01
 ### Changed

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ These methods are included:
 * SugarUtils::File.write
 * SugarUtils::File.read_json
 * SugarUtils::File.write_json
+* SugarUtils::File.append
 
 These methods will probably be included in the future:
 


### PR DESCRIPTION
This will be useful in its own right, and simplifies the mode and perm options.
But it will also make it easier to add atomic write support to .write without having to think about append support.