### PR TITLE
Extracting and exposing some internal implementaton details

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,8 +16,10 @@ RSpec/EmptyExampleGroup:
 
 # Because of the way that blocks are used in RSpecs can end up being long when
 # example groups are nested or many examples are checked.
+# A similar pattern exists in the DSL for gemspec files.
 Metrics/BlockLength:
   Exclude:
+    - '*.gemspec'
     - 'spec/**/*'
 
 RSpec/ExpectInHook:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: ruby
 rvm:
   - 2.2
   - 2.3
-  - 2.4
-  - 2.5
-  - 2.6
+  - 2.4.5
+  - 2.5.4
+  - 2.6.2
   - ruby-head
   - jruby
 matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   also create a new file if it does not yet exist
 - SugarUtils::scrub_encoding, which is used for cleaning badly encoded
   characters out of a string
+- SugarUtils::File.change_access, a wrapper for changing ownership and
+  permissions of a file
 ### Removed
 - append support in SugarUtils::File.write (could have been specified by { mode: 'a })
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - SugarUtils::File.append, which is explicitly for appending to a file. It will
   also create a new file if it does not yet exist
+- SugarUtils::scrub_encoding, which is used for cleaning badly encoded
+  characters out of a string
 ### Removed
 - append support in SugarUtils::File.write (could have been specified by { mode: 'a })
 ### Changed

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ These methods are included:
 * SugarUtils.scrub_encoding
 * SugarUtils::File.flock_shared
 * SugarUtils::File.flock_exclusive
+* SugarUtils::File.change_access
 * SugarUtils::File.read
 * SugarUtils::File.write
 * SugarUtils::File.read_json

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ These methods are included:
 
 * SugarUtils.ensure_boolean
 * SugarUtils.ensure_integer
+* SugarUtils.scrub_encoding
 * SugarUtils::File.flock_shared
 * SugarUtils::File.flock_exclusive
 * SugarUtils::File.read

--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,8 @@
 
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
+require 'cucumber'
+require 'cucumber/rake/task'
 require 'rubocop/rake_task'
 require 'bundler/audit/task'
 require 'yard'
@@ -12,6 +14,9 @@ require 'English'
 
 RSpec::Core::RakeTask.new(:spec) do |task|
   # task.rspec_opts = '--warnings'
+end
+
+Cucumber::Rake::Task.new(:features) do |task|
 end
 
 RuboCop::RakeTask.new(:rubocop) do |task|
@@ -48,4 +53,4 @@ Yardstick::Rake::Measurement.new(:yardstick_measure) do |measurement|
   measurement.output = 'tmp/yard_coverage.txt'
 end
 
-task default: %i[spec rubocop yardstick_measure bundle:audit license_finder]
+task default: %i[spec features rubocop yardstick_measure bundle:audit license_finder]

--- a/features/append_file.feature
+++ b/features/append_file.feature
@@ -1,0 +1,46 @@
+Feature: Append to a file
+
+Scenario: Append a missing file
+  When I run the following Ruby code:
+    """ruby
+    require 'sugar_utils'
+    SugarUtils::File.append('dir/test', 'foobar')
+    """
+  Then the file named "dir/test" should contain exactly:
+    """
+    foobar
+    """
+
+Scenario: Append an existing file
+  Given a file named "dir/test" with "foobar"
+  When I run the following Ruby code:
+    """ruby
+    require 'sugar_utils'
+    SugarUtils::File.append('dir/test', 'deadbeef')
+    """
+  Then the file named "dir/test" should contain exactly:
+    """
+    foobardeadbeef
+    """
+
+# TODO: Fix the owner/group setting check
+Scenario: Append a file and reset its permissions
+  Given a file named "dir/test" with "foobar"
+  When I run the following Ruby code:
+    """ruby
+    require 'sugar_utils'
+    SugarUtils::File.append(
+      'dir/test',
+      'deadbeef',
+      # owner: 'nobody',
+      # group: 'nogroup',
+      mode:  0o777
+    )
+    """
+  Then the file named "dir/test" should contain exactly:
+    """
+    foobardeadbeef
+    """
+    And the file named "dir/test" should have permissions "777"
+    # And the file named "dir/test" should have owner "nobody"
+    # And the file named "dir/test" should have group "nogroup"

--- a/features/change_file_access.feature
+++ b/features/change_file_access.feature
@@ -1,0 +1,27 @@
+Feature: Change a files ownership and permissions
+
+# TODO: Fix the owner/group setting check. I need to figure out how to execute
+# these scenarios correctly across various environments.
+
+Scenario: All the values are skipped
+  Given a file named "test" with "foobar"
+  When I run the following Ruby code:
+    """ruby
+    require 'sugar_utils'
+    SugarUtils::File.change_access('test', nil, nil, nil)
+    """
+  # Then the file named "test" should have permissions "644"
+    # And the file named "test" should have owner "nobody"
+    # And the file named "test" should have group "nogroup"
+
+Scenario: All the values are set
+  Given a file named "test" with "foobar"
+  When I run the following Ruby code:
+    """ruby
+    require 'sugar_utils'
+    # SugarUtils::File.change_access('test', 'nobody', 'nogroup', 0o777)
+    SugarUtils::File.change_access('test', nil, nil, 0o777)
+    """
+  Then the file named "test" should have permissions "777"
+    # And the file named "test" should have owner "nobody"
+    # And the file named "test" should have group "nogroup"

--- a/features/ensure_boolean.feature
+++ b/features/ensure_boolean.feature
@@ -1,0 +1,34 @@
+
+Feature: Ensure the specified value is a boolean
+
+Scenario: nil is false
+  When I run the following Ruby code:
+    """ruby
+    require 'sugar_utils'
+    puts SugarUtils.ensure_boolean(nil)
+    """
+  Then the output should contain "false"
+
+Scenario: false is false
+  When I run the following Ruby code:
+    """ruby
+    require 'sugar_utils'
+    puts SugarUtils.ensure_boolean(false)
+    """
+  Then the output should contain "false"
+
+Scenario: String of 'false' is false
+  When I run the following Ruby code:
+    """ruby
+    require 'sugar_utils'
+    puts SugarUtils.ensure_boolean('false')
+    """
+  Then the output should contain "false"
+
+Scenario: Any other value is true
+  When I run the following Ruby code:
+    """ruby
+    require 'sugar_utils'
+    puts SugarUtils.ensure_boolean('value')
+    """
+  Then the output should contain "true"

--- a/features/ensure_integer.feature
+++ b/features/ensure_integer.feature
@@ -1,0 +1,19 @@
+Feature: Ensure the specified value is an integer
+
+Scenario: Convert Floats to Integers
+  When I run the following Ruby code:
+    """ruby
+    require 'sugar_utils'
+    puts SugarUtils.ensure_integer(123.456)
+    """
+  Then the output should contain "123"
+
+Scenario: Convert Strings of Integers to Integers
+  When I run the following Ruby code:
+    """ruby
+    require 'sugar_utils'
+    puts SugarUtils.ensure_integer('123.456')
+    """
+  Then the output should contain "123"
+
+

--- a/features/lock_file.feature
+++ b/features/lock_file.feature
@@ -1,0 +1,26 @@
+# TODO: Fill in this feature
+Feature: Operate locks on files
+
+Scenario: Shared lock
+  Given a file named "test" with "foobar"
+  When I run the following Ruby code:
+    """ruby
+    require 'sugar_utils'
+    File.open('test') do |file|
+      SugarUtils::File.flock_shared(file)
+      puts file.read
+    end
+    """
+  Then the file named "test" should contain "foobar"
+
+Scenario: Exclusive lock
+  Given a file named "test" with "foobar"
+  When I run the following Ruby code:
+    """ruby
+    require 'sugar_utils'
+    File.open('test') do |file|
+      SugarUtils::File.flock_exclusive(file)
+      puts file.read
+    end
+    """
+  Then the file named "test" should contain "foobar"

--- a/features/read_file.feature
+++ b/features/read_file.feature
@@ -1,0 +1,30 @@
+Feature: Read a file
+
+Scenario: Read a missing file with a default value
+  When I run the following Ruby code:
+    """ruby
+    require 'sugar_utils'
+    puts SugarUtils::File.read(
+      'test', value_on_missing: 'missing', raise_on_missing: false
+    )
+    """
+  Then the output should contain "missing"
+
+Scenario: Read an existing file
+  Given a file named "test" with "foobar"
+  When I run the following Ruby code:
+    """ruby
+    require 'sugar_utils'
+    puts SugarUtils::File.read('test')
+    """
+  Then the output should contain "foobar"
+
+Scenario: Read an existing file and scurb encoding errors
+  Given a file named "test" with "test"
+  When I run the following Ruby code:
+    """ruby
+    require 'sugar_utils'
+    File.write('test', %(foo\\x92bar\\x93))
+    puts SugarUtils::File.read('test', scrub_encoding: true)
+    """
+  Then the output should contain "foobar"

--- a/features/read_json_file.feature
+++ b/features/read_json_file.feature
@@ -1,0 +1,43 @@
+Feature: Read a file
+
+Scenario: Read a missing file with a default value
+  When I run the following Ruby code:
+    """ruby
+    require 'sugar_utils'
+    MultiJson.use(:ok_json)
+
+    puts SugarUtils::File.read_json('test.json', raise_on_missing: false)
+    """
+  Then the output should contain "{}"
+
+Scenario: Read an existing file
+  Given a file named "test.json" with:
+    """
+    {"key":"value"}
+    """
+  When I run the following Ruby code:
+    """ruby
+    require 'sugar_utils'
+    MultiJson.use(:ok_json)
+
+    puts SugarUtils::File.read_json('test.json')
+    """
+  Then the output should contain:
+    """
+    {"key"=>"value"}
+    """
+
+Scenario: Read an existing file and scurb encoding errors
+  Given a file named "test.json" with "test"
+  When I run the following Ruby code:
+    """ruby
+    require 'sugar_utils'
+    MultiJson.use(:ok_json)
+
+    File.write('test.json', %({\"key\":\"foo\\x92bar\\x93\"}))
+    puts SugarUtils::File.read_json('test.json', scrub_encoding: true)
+    """
+  Then the output should contain:
+    """
+    {"key"=>"foobar"}
+    """

--- a/features/scrub_encoding.feature
+++ b/features/scrub_encoding.feature
@@ -1,0 +1,25 @@
+Feature: Ensure the specified value is an integer
+
+Scenario: Pass through string without encoding errors
+  When I run the following Ruby code:
+    """ruby
+    require 'sugar_utils'
+    puts SugarUtils.scrub_encoding('foobar')
+    """
+  Then the output should contain "foobar"
+
+Scenario: Erase encoding errors in the string
+  When I run the following Ruby code:
+    """ruby
+    require 'sugar_utils'
+    puts SugarUtils.scrub_encoding(%(foo\\x92bar\\x93))
+    """
+  Then the output should contain "foobar"
+
+Scenario: Replace encoding errors in the string
+  When I run the following Ruby code:
+    """ruby
+    require 'sugar_utils'
+    puts SugarUtils.scrub_encoding(%(foo\\x92bar\\x93), 'xxx')
+    """
+  Then the output should contain "fooxxxbarxxx"

--- a/features/step_definitions/steps.rb
+++ b/features/step_definitions/steps.rb
@@ -1,0 +1,36 @@
+When('I run the following Ruby code:') do |code|
+  run_command_and_stop %(ruby -e "#{code}")
+end
+
+# Copying the pattern for this step from the default Aruba step for checking
+# the permissions of a file.
+# @see lib/aruba/cucumber/file.rb
+Then(/^the (?:file|directory)(?: named)? "([^"]*)" should( not)? have owner "([^"]*)"$/) do |path, negated, owner|
+  if negated
+    expect(path).not_to have_owner(owner)
+  else
+    expect(path).to have_owner(owner)
+  end
+end
+
+# Copying the pattern for this step from the default Aruba step for checking
+# the permissions of a file.
+# @see lib/aruba/cucumber/file.rb
+Then(/^the (?:file|directory)(?: named)? "([^"]*)" should( not)? have group "([^"]*)"$/) do |path, negated, group|
+  if negated
+    expect(path).not_to have_group(group)
+  else
+    expect(path).to have_group(group)
+  end
+end
+
+# Copying the pattern for this step from the default Aruba step for checking
+# the permissions of a file.
+# @see lib/aruba/cucumber/file.rb
+Then(/^the (?:file|directory)(?: named)? "([^"]*)" should( not)? have modification time "([^"]*)"$/) do |path, negated, modification_time|
+  if negated
+    expect(expand_path(path)).not_to have_mtime(modification_time.to_i)
+  else
+    expect(expand_path(path)).to have_mtime(modification_time.to_i)
+  end
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'aruba/cucumber'
+
+# @see spec/spec_helper.rb
+RSpec::Matchers.define :have_owner do |expected|
+  match do |actual|
+    next false unless File.exist?(actual)
+
+    @actual   = Etc.getpwuid(File.stat(filename).uid).name
+    @expected = expected
+    values_match?(@expected, @actual)
+  end
+end
+
+RSpec::Matchers.define :have_group do |expected|
+  match do |actual|
+    next false unless File.exist?(actual)
+
+    @actual   = Etc.getgrgid(File.stat(actual).gid).name
+    @expected = expected
+    values_match?(@expected, @actual)
+  end
+end
+
+RSpec::Matchers.define :have_mtime do |expected|
+  match do |actual|
+    next false unless File.exist?(actual)
+
+    @actual   = File.stat(actual).mtime.to_i
+    @expected = expected
+    values_match?(@expected, @actual)
+  end
+end

--- a/features/touch_file.feature
+++ b/features/touch_file.feature
@@ -1,0 +1,28 @@
+Feature: Touch a file
+
+Scenario: Touch a file
+  When I run the following Ruby code:
+    """ruby
+    require 'sugar_utils'
+    puts SugarUtils::File.touch('dir/test')
+    """
+  Then the file named "dir/test" should exist
+
+# TODO: Fix the owner/group setting check
+Scenario: Touch a file and reset its permissions and mtime
+  When I run the following Ruby code:
+    """ruby
+    require 'sugar_utils'
+    puts SugarUtils::File.touch(
+      'dir/test',
+      # owner: 'nobody',
+      # group: 'nogroup',
+      mode:  0o777,
+      mtime: 0
+    )
+    """
+  Then the file named "dir/test" should exist
+    And the file named "dir/test" should have permissions "777"
+    And the file named "dir/test" should have modification time "0"
+    # And the file named "dir/test" should have owner "nobody"
+    # And the file named "dir/test" should have group "nogroup"

--- a/features/write_file.feature
+++ b/features/write_file.feature
@@ -1,0 +1,46 @@
+Feature: Write to a file
+
+Scenario: Write a file
+  When I run the following Ruby code:
+    """ruby
+    require 'sugar_utils'
+    puts SugarUtils::File.write('dir/test', 'foobar')
+    """
+  Then the file named "dir/test" should contain exactly:
+    """
+    foobar
+    """
+
+Scenario: Overwrite a file
+  Given a file named "dir/test" with "deadbeef"
+  When I run the following Ruby code:
+    """ruby
+    require 'sugar_utils'
+    puts SugarUtils::File.write('dir/test', 'foobar')
+    """
+  Then the file named "dir/test" should contain exactly:
+    """
+    foobar
+    """
+
+# TODO: Fix the owner/group setting check
+Scenario: Overwrite a file and reset its permissions
+  Given a file named "dir/test" with "deadbeef"
+  When I run the following Ruby code:
+    """ruby
+    require 'sugar_utils'
+    puts SugarUtils::File.write(
+      'dir/test',
+      'foobar',
+      # owner: 'nobody',
+      # group: 'nogroup',
+      mode:  0o777
+    )
+    """
+  Then the file named "dir/test" should contain exactly:
+    """
+    foobar
+    """
+    And the file named "dir/test" should have permissions "777"
+    # And the file named "dir/test" should have owner "nobody"
+    # And the file named "dir/test" should have group "nogroup"

--- a/features/write_json_file.feature
+++ b/features/write_json_file.feature
@@ -1,0 +1,52 @@
+Feature: Write JSON to a file
+
+Scenario: Write a file
+  When I run the following Ruby code:
+    """ruby
+    require 'sugar_utils'
+    MultiJson.use(:ok_json)
+
+    puts SugarUtils::File.write_json('dir/test.json', { key: :value })
+    """
+  Then the file named "dir/test.json" should contain exactly:
+    """
+    {"key":"value"}
+    """
+
+Scenario: Overwrite a file
+  Given a file named "dir/test.json" with "deadbeef"
+  When I run the following Ruby code:
+    """ruby
+    require 'sugar_utils'
+    MultiJson.use(:ok_json)
+
+    puts SugarUtils::File.write_json('dir/test.json', { key: :value })
+    """
+  Then the file named "dir/test.json" should contain exactly:
+    """
+    {"key":"value"}
+    """
+
+# TODO: Fix the owner/group setting check
+Scenario: Overwrite a file and reset its permissions
+  Given a file named "dir/test.json" with "deadbeef"
+  When I run the following Ruby code:
+    """ruby
+    require 'sugar_utils'
+    MultiJson.use(:ok_json)
+
+    puts SugarUtils::File.write_json(
+      'dir/test.json',
+      { key: :value },
+      # owner: 'nobody',
+      # group: 'nogroup',
+      mode:  0o777
+    )
+    """
+  Then the file named "dir/test.json" should contain exactly:
+    """
+    {"key":"value"}
+    """
+    And the file named "dir/test.json" should have permissions "777"
+    # And the file named "dir/test.json" should have owner "nobody"
+    # And the file named "dir/test.json" should have group "nogroup"

--- a/lib/sugar_utils.rb
+++ b/lib/sugar_utils.rb
@@ -3,6 +3,7 @@
 require 'sugar_utils/version'
 require 'sugar_utils/file'
 
+# @api
 module SugarUtils
   # @param value [Object]
   #

--- a/lib/sugar_utils.rb
+++ b/lib/sugar_utils.rb
@@ -26,4 +26,30 @@ module SugarUtils
 
     Float(value).to_i
   end
+
+  # @overload scrub_encoding(data)
+  #   Scrub the string's encoding, and replace any bad characters with ''.
+  #   @param data [String]
+  # @overload scrub_encoding(data, replacement_character)
+  #   Scrub the string's encoding, and replace any bad characters with the
+  #   specified character.
+  #   @param data [String]
+  #   @param replacement_character [String]
+  #
+  # @return [String]
+  def self.scrub_encoding(data, replacement_character = nil)
+    replacement_character = '' unless replacement_character.is_a?(String)
+
+    # If the Ruby version being used supports String#scrub, then just use it.
+    return data.scrub(replacement_character) if data.respond_to?(:scrub)
+
+    # Otherwise, fall back to String#encode.
+    data.encode(
+      data.encoding,
+      'binary',
+      invalid: :replace,
+      undef:   :replace, # rubocop:disable Layout/AlignHash
+      replace: replacement_character
+    )
+  end
 end

--- a/lib/sugar_utils/file.rb
+++ b/lib/sugar_utils/file.rb
@@ -6,7 +6,7 @@ require 'multi_json'
 require 'timeout'
 
 module SugarUtils
-  module File
+  module File # rubocop:disable Metrics/ModuleLength
     class Error < StandardError; end
 
     # @param file [File]
@@ -183,8 +183,8 @@ module SugarUtils
       FileUtils.chown(owner, group, filename)
     rescue Timeout::Error
       raise(Error, "Unable to write #{filename} because it is locked")
-    rescue SystemCallError, IOError => boom
-      raise(Error, "Unable to write #{filename} with #{boom}")
+    rescue SystemCallError, IOError => e
+      raise(Error, "Unable to write #{filename} with #{e}")
     end
 
     # Write the data parameter as JSON to the filename path.
@@ -270,8 +270,8 @@ module SugarUtils
       FileUtils.chown(owner, group, filename)
     rescue Timeout::Error
       raise(Error, "Unable to write #{filename} because it is locked")
-    rescue SystemCallError, IOError => boom
-      raise(Error, "Unable to write #{filename} with #{boom}")
+    rescue SystemCallError, IOError => e
+      raise(Error, "Unable to write #{filename} with #{e}")
     end
 
     ############################################################################

--- a/lib/sugar_utils/file.rb
+++ b/lib/sugar_utils/file.rb
@@ -48,7 +48,7 @@ module SugarUtils
     # @raise [SugarUtils::File::Error]
     #
     # @return [String]
-    def self.read(filename, options = {}) # rubocop:disable MethodLength, AbcSize, CyclomaticComplexity, PerceivedComplexity
+    def self.read(filename, options = {}) # rubocop:disable MethodLength
       options[:value_on_missing] ||= ''
       options[:raise_on_missing] = true if options[:raise_on_missing].nil?
 
@@ -60,23 +60,7 @@ module SugarUtils
 
       return result unless options[:scrub_encoding]
 
-      replacement_character =
-        if options[:scrub_encoding].is_a?(String)
-          options[:scrub_encoding]
-        else
-          ''
-        end
-      if result.respond_to?(:scrub)
-        result.scrub(replacement_character)
-      else
-        result.encode(
-          result.encoding,
-          'binary',
-          invalid: :replace,
-          undef:   :replace, # rubocop:disable Layout/AlignHash
-          replace: replacement_character
-        )
-      end
+      SugarUtils.scrub_encoding(result, options[:scrub_encoding])
     rescue SystemCallError, IOError
       raise(Error, "Cannot read #{filename}") if options[:raise_on_missing]
 

--- a/lib/sugar_utils/file/write_options.rb
+++ b/lib/sugar_utils/file/write_options.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module SugarUtils
+  module File
+    # @api private
+    class WriteOptions
+      # @parma filename [String]
+      # @param options [Hash]
+      def initialize(filename, options)
+        @filename = filename
+        @options  = options
+
+        return unless filename && ::File.exist?(filename)
+
+        file_stat       = ::File::Stat.new(filename)
+        @existing_owner = file_stat.uid
+        @existing_group = file_stat.gid
+      end
+
+      # @return [Boolean]
+      def flush?
+        @options[:flush] || false
+      end
+
+      # @overload perm
+      #   The default permission is 0o644
+      # @overload perm(default_value)
+      #   @param default_value [nil, Integer]
+      #   Override the default_value including allowing nil.
+      #
+      # @return [Integer]
+      def perm(default_value = 0o644)
+        # NOTE: We are using the variable name 'perm' because that is the name
+        # of the argument used by File.open.
+        @options[:mode] || @options[:perm] || default_value
+      end
+
+      # @return [String, Integer]
+      def owner
+        @options[:owner] || @existing_owner
+      end
+
+      # @return [String, Intekuuger]
+      def group
+        @options[:group] || @existing_group
+      end
+
+      # @param keys [Array]
+      # @return [Hash]
+      def slice(*args)
+        keys = args.flatten.compact
+        @options.select { |k| keys.include?(k) }
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -80,7 +80,7 @@ RSpec::Matchers.define :have_mtime do |expected|
   match do |actual|
     next false unless File.exist?(actual)
 
-    @actual   = File.stat(actual).mtime
+    @actual   = File.stat(actual).mtime.to_i
     @expected = expected
     values_match?(@expected, @actual)
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,7 @@ require 'simplecov'
 SimpleCov.start
 
 require 'sugar_utils'
+MultiJson.use(:ok_json)
 
 SolidAssert.enable_assertions
 

--- a/spec/sugar_utils/file/write_options_spec.rb
+++ b/spec/sugar_utils/file/write_options_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe SugarUtils::File::WriteOptions do
+  subject(:write_options) { described_class.new(filename, options) }
+
+  let(:filename) { nil }
+
+  before do
+    allow(File).to receive(:exist?).with('missing').and_return(false)
+    allow(File).to receive(:exist?).with('found').and_return(true)
+    allow(File::Stat).to receive(:new).with('found').and_return(
+      instance_double(File::Stat, uid: :uid, gid: :gid)
+    )
+  end
+
+  describe '#flush?' do
+    subject { write_options.flush? }
+
+    inputs  :options
+    it_with Hash[],              false
+    it_with Hash[flush: :flush], :flush
+  end
+
+  describe '#perm' do
+    subject { write_options.perm(*args) }
+
+    inputs  :options, :args
+    it_with Hash[],                         [],                0o644
+    it_with Hash[],                         %i[default_value], :default_value
+    it_with Hash[mode: :mode],              [],                :mode
+    it_with Hash[mode: :mode],              %i[default_value], :mode
+    it_with Hash[perm: :perm, mode: :mode], [],                :mode
+    it_with Hash[perm: :perm, mode: :mode], %i[default_value], :mode
+    it_with Hash[perm: :perm],              [],                :perm
+    it_with Hash[perm: :perm],              %i[default_value], :perm
+  end
+
+  describe '#owner' do
+    subject { write_options.owner }
+
+    inputs  :filename, :options
+    it_with nil,       Hash[],              nil
+    it_with 'missing', Hash[],              nil
+    it_with 'found',   Hash[],              :uid
+    it_with nil,       Hash[owner: :owner], :owner
+    it_with 'missing', Hash[owner: :owner], :owner
+    it_with 'found',   Hash[owner: :owner], :owner
+  end
+
+  describe '#group' do
+    subject { write_options.group }
+
+    inputs  :filename, :options
+    it_with nil,       Hash[],              nil
+    it_with 'missing', Hash[],              nil
+    it_with 'found',   Hash[],              :gid
+    it_with nil,       Hash[group: :group], :group
+    it_with 'missing', Hash[group: :group], :group
+    it_with 'found',   Hash[group: :group], :group
+  end
+
+  describe '#slice' do
+    subject { write_options.slice(*args) }
+
+    let(:options) { { key1: :value1, key2: :value2, key3: :value3 } }
+
+    inputs  :args
+    it_with [],                        Hash[]
+    it_with %i[key1],                  Hash[key1: :value1]
+    it_with %i[key2],                  Hash[key2: :value2]
+    it_with %i[key3],                  Hash[key3: :value3]
+    it_with %i[key1 key3],             Hash[key1: :value1, key3: :value3]
+    it_with [%i[key1], nil, %i[key3]], Hash[key1: :value1, key3: :value3]
+  end
+end

--- a/spec/sugar_utils/file_spec.rb
+++ b/spec/sugar_utils/file_spec.rb
@@ -59,7 +59,7 @@ describe SugarUtils::File do
     end
 
     context 'when file present' do
-      before { write('filename', "foo\x92bar") }
+      before { write('filename', 'foobar') }
 
       # rubocop:disable RSpec/NestedGroups
       context 'when locked' do
@@ -80,15 +80,15 @@ describe SugarUtils::File do
         before do
           expect(described_class).to receive(:flock_shared)
             .with(kind_of(File), options)
+          allow(SugarUtils).to receive(:scrub_encoding)
+            .with('foobar', scrub_encoding)
+            .and_return(:scrubbed_data)
         end
 
         inputs  :scrub_encoding
-        it_with nil,            "foo\x92bar"
-        it_with false,          "foo\x92bar"
-        it_with true,           'foobar'
-        it_with '',             'foobar'
-        it_with 'x',            'fooxbar'
-        it_with 'xxx',          'fooxxxbar'
+        it_with nil,             'foobar'
+        it_with false,           'foobar'
+        it_with :scrub_encoding, :scrubbed_data
       end
       # rubocop:enable RSpec/NestedGroups
     end

--- a/spec/sugar_utils_spec.rb
+++ b/spec/sugar_utils_spec.rb
@@ -36,4 +36,22 @@ describe SugarUtils do
     it_with          '123',              123
     it_with          '123.234',          123
   end
+
+  describe '.scrub_encoding' do
+    subject { described_class.scrub_encoding(data, *args) }
+
+    inputs  :data,            :args
+    it_with 'foobar',         [],      'foobar'
+    it_with 'foobar',         [nil],   'foobar'
+    it_with 'foobar',         [111],   'foobar'
+    it_with 'foobar',         [''],    'foobar'
+    it_with 'foobar',         ['x'],   'foobar'
+    it_with 'foobar',         ['xxx'], 'foobar'
+    it_with "foo\x92bar\x93", [],      'foobar'
+    it_with "foo\x92bar\x93", [nil],   'foobar'
+    it_with "foo\x92bar\x93", [111],   'foobar'
+    it_with "foo\x92bar\x93", [''],    'foobar'
+    it_with "foo\x92bar\x93", ['x'],   'fooxbarx'
+    it_with "foo\x92bar\x93", ['xxx'], 'fooxxxbarxxx'
+  end
 end

--- a/sugar_utils.gemspec
+++ b/sugar_utils.gemspec
@@ -23,7 +23,9 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'multi_json',   '~> 1.0'
   spec.add_dependency 'solid_assert', '~> 1.0'
 
+  spec.add_development_dependency 'aruba',              '~> 0.14.9'
   spec.add_development_dependency 'bundler',            '~> 1.7'
+  spec.add_development_dependency 'cucumber',           '~> 3.1.2'
   spec.add_development_dependency 'fakefs',             '~> 0.7'
   spec.add_development_dependency 'rake',               '~> 12.0'
   spec.add_development_dependency 'rspec',              '~> 3.8.0'

--- a/sugar_utils.gemspec
+++ b/sugar_utils.gemspec
@@ -34,7 +34,9 @@ Gem::Specification.new do |spec|
   # without limiting.
   spec.add_development_dependency 'bundler-audit'
   spec.add_development_dependency 'license_finder'
-  spec.add_development_dependency 'rubocop'
+  # HACK: Limit ourselves to Rubocop versions which still support Ruby2.2. This
+  # can be removed once we drop support for Ruby2.2.
+  spec.add_development_dependency 'rubocop', '~> 0.68.0'
   spec.add_development_dependency 'rubocop-rspec'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'yard'


### PR DESCRIPTION
This should all reduce duplication, expose some more features, and make it easier to eventually write the atomic write function.
This includes:
* handling the options to the write methods in a private class called SugarUtils::File::WriteOptions
* expose SugarUtils.scrub_encoding as a public method
* expose changing ownership/group/permission as a single operation, SugarUtils::File.change_access
* adding cucumber documentation. This will also provide a place to do integration testing, so that rspec unit tests can be more isolated when appropriate