### PR TITLE
Add 'Elsewhere on the web' to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,21 @@ These methods might be added in the future:
 * http_get_file
 * timeout_retry
 
+## Elsewhere on the web
+
+Links to other places on the web where this projects exists:
+
+* [Code Climate](https://codeclimate.com/github/sugarcrm/sugar_utils)
+* [CucumberPro](https://app.cucumber.pro/projects/sugar_utils)
+* [InchCI](http://inch-ci.org/github/sugarcrm/sugar_utils)
+* [Github](https://github.com/sugarcrm/sugar_utils)
+* [OpenHub](https://www.openhub.net/p/sugar_utils)
+* [RubyDoc](http://rubydoc.org/gems/sugar_utils)
+* [RubyGems](https://rubygems.org/gems/sugar_utils)
+* [Ruby LibHunt](https://ruby.libhunt.com/sugar_utils-alternatives)
+* [Ruby Toolbox](https://www.ruby-toolbox.com/projects/sugar_utils)
+* [TravisCI](https://travis-ci.org/sugarcrm/sugar_utils)
+
 ## Contributing
 
 See [CONTRIBUTING](CONTRIBUTING.md) for how you can contribute changes back into this project.

--- a/README.md
+++ b/README.md
@@ -27,20 +27,6 @@ These methods are included:
 * SugarUtils::File.write_json
 * SugarUtils::File.append
 
-These methods will probably be included in the future:
-
-* sizeof_dir
-* find_files
-* find_file!
-* gzip
-* gunzip
-* tarball
-* untarball
-* tarball_list
-* encrypt
-* http_get_file
-* timeout_retry
-
 ## Installation
 
 Add this line to your application's Gemfile:
@@ -60,6 +46,22 @@ Or install it yourself as:
 ```bash
 $ gem install sugar_utils
 ```
+
+## Roadmap
+
+These methods might be added in the future:
+
+* sizeof_dir
+* find_files
+* find_file!
+* gzip
+* gunzip
+* tarball
+* untarball
+* tarball_list
+* encrypt
+* http_get_file
+* timeout_retry
 
 ## Contributing
 


### PR DESCRIPTION
This section should contain a list of all the places where this project exists on the web. Including the Github repository, CI tool pages, package page, and profile pages.

This intentionally duplicates some of the links included in the badges.