### PR TITLE
Add a `bundler:outdated` task and include the `yard` task on the defaults

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -54,4 +54,14 @@ Yardstick::Rake::Measurement.new(:yardstick_measure) do |measurement|
   measurement.output = 'tmp/yard_coverage.txt'
 end
 
+desc 'Show which specified gems are outdated'
+task 'bundle:outdated' do
+  bundle_outdated_report_pathname =
+    Pathname(Rake.application.original_dir).join('tmp', 'bundle_outdated.txt')
+  bundle_outdated_report_pathname.dirname.mkpath
+
+  # TODO: Should consider re-writing this without using `tee`.
+  sh("bundle outdated --only-explicit | tee #{bundle_outdated_report_pathname}")
+end
+
 task default: %i[spec features rubocop yardstick_measure bundle:audit license_finder]

--- a/Rakefile
+++ b/Rakefile
@@ -64,4 +64,4 @@ task 'bundle:outdated' do
   sh("bundle outdated --only-explicit | tee #{bundle_outdated_report_pathname}")
 end
 
-task default: %i[spec features rubocop yardstick_measure bundle:audit license_finder]
+task default: %i[spec features rubocop yard yardstick_measure bundle:audit license_finder]

--- a/lib/sugar_utils/file/write_options.rb
+++ b/lib/sugar_utils/file/write_options.rb
@@ -7,8 +7,10 @@ module SugarUtils
       # @parma filename [String]
       # @param options [Hash]
       def initialize(filename, options)
-        @filename = filename
-        @options  = options
+        @filename       = filename
+        @options        = options
+        @existing_owner = nil
+        @existing_group = nil
 
         return unless filename && ::File.exist?(filename)
 

--- a/lib/sugar_utils/file/write_options.rb
+++ b/lib/sugar_utils/file/write_options.rb
@@ -4,7 +4,7 @@ module SugarUtils
   module File
     # @api private
     class WriteOptions
-      # @parma filename [String]
+      # @param filename [String]
       # @param options [Hash]
       def initialize(filename, options)
         @filename       = filename
@@ -47,7 +47,7 @@ module SugarUtils
         @options[:group] || @existing_group
       end
 
-      # @param keys [Array]
+      # @param args [Array]
       # @return [Hash]
       def slice(*args)
         keys = args.flatten.compact


### PR DESCRIPTION
Make a small fix to yardocs.
And a small change to File::WriteOptions which resolves a Ruby warning.